### PR TITLE
Remove Component in ClickableImageGridList because it prevents react …

### DIFF
--- a/DeveloperProfile/ClientApp/src/components/QnA/ClickableImageGridList.js
+++ b/DeveloperProfile/ClientApp/src/components/QnA/ClickableImageGridList.js
@@ -1,11 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';
-//import IconButton from '@material-ui/core/IconButton';
-//import StarBorderIcon from '@material-ui/icons/StarBorder';
-//import tileData from './tileData';
 
 
 const useStyles = makeStyles((theme) => ({


### PR DESCRIPTION
…from building in production. Clear unused import declarations. Clean up code.